### PR TITLE
Enable seismic viewer playback over serial

### DIFF
--- a/app/app_state.py
+++ b/app/app_state.py
@@ -19,3 +19,7 @@ viewer_seismic_files = {}           # Files and their traces for the viewer
 viewer_all_traces = []              # Flat list of all traces
 viewer_selected_trace_index = None  # Index of the selected trace
 viewer_data_dirty = threading.Event() # Event to notify GUI to update viewer
+
+viewer_playback_status = "Idle"
+viewer_playback_status_dirty = False
+viewer_playback_amplitude = 1600

--- a/app/gui.py
+++ b/app/gui.py
@@ -149,7 +149,26 @@ def _update_viewer_detailed_plot():
         dpg.fit_axis_data(x_axis)
         dpg.fit_axis_data(y_axis)
     with dpg.group(horizontal=True, parent=parent_container):
-        dpg.add_button(label="Process for Shaking Table", callback=svh.process_selected_trace, width=-1, height=30)
+        dpg.add_button(label="Process", callback=svh.process_selected_trace, width=180, height=30)
+        dpg.add_button(label="Play on Table", tag="viewer_play_button", callback=svh.start_playback, width=180, height=30)
+        dpg.add_button(label="Stop", tag="viewer_stop_button", callback=svh.stop_playback, width=120, height=30)
+    dpg.add_slider_int(label="Playback Amplitude (steps)",
+                       tag="viewer_playback_amplitude_slider",
+                       default_value=app_state.viewer_playback_amplitude,
+                       min_value=100,
+                       max_value=10000,
+                       callback=_viewer_amplitude_changed,
+                       parent=parent_container)
+    dpg.add_text(f"Status: {app_state.viewer_playback_status}",
+                 tag="viewer_playback_status_label",
+                 parent=parent_container)
+
+
+def _viewer_amplitude_changed(sender, app_data):
+    """Stores the latest amplitude selected by the user for playback."""
+    with app_state.data_lock:
+        app_state.viewer_playback_amplitude = int(app_data)
+
 
 # <<< END: VIEWER FUNCTIONS >>>
 
@@ -161,7 +180,7 @@ def update_gui_callbacks():
         _update_viewer_file_tree()
         _update_viewer_detailed_plot()
         app_state.viewer_data_dirty.clear()
-    
+
     # <<< REMOVED LOGIC RELATED TO THE DELETED SISMOS LOCALES TAB >>>
     # if app_state.sismo_list_dirty:
     #     update_sismo_visual_list()
@@ -170,6 +189,9 @@ def update_gui_callbacks():
     # if dpg.does_item_exist("sismo_status"): dpg.set_value("sismo_status", app_state.sismo_status_message)
     # if dpg.does_item_exist("sismo_playback_status"): dpg.set_value("sismo_playback_status", app_state.sismo_playback_status_message)
     
+    status_dirty = False
+    status_message = ""
+    is_playing = False
     with app_state.data_lock:
         if app_state.x_data and app_state.y_data and dpg.does_item_exist("series_real_comp"):
             dpg.set_value("series_real_comp", [list(app_state.x_data), list(app_state.y_data)])
@@ -188,6 +210,30 @@ def update_gui_callbacks():
             if dpg.does_item_exist("console_recv_container"): dpg.set_y_scroll("console_recv_container", -1.0)
             if dpg.does_item_exist("console_send_container"): dpg.set_y_scroll("console_send_container", -1.0)
             app_state.log_dirty = False
+
+        if app_state.viewer_playback_status_dirty:
+            status_dirty = True
+            status_message = app_state.viewer_playback_status
+            app_state.viewer_playback_status_dirty = False
+
+        is_playing = app_state.sismo_running
+
+    is_connected = bool(app_state.ser and app_state.ser.is_open)
+
+    if dpg.does_item_exist("viewer_play_button"):
+        if is_playing or not is_connected:
+            dpg.disable_item("viewer_play_button")
+        else:
+            dpg.enable_item("viewer_play_button")
+
+    if dpg.does_item_exist("viewer_stop_button"):
+        if is_playing:
+            dpg.enable_item("viewer_stop_button")
+        else:
+            dpg.disable_item("viewer_stop_button")
+
+    if status_dirty and dpg.does_item_exist("viewer_playback_status_label"):
+        dpg.set_value("viewer_playback_status_label", f"Status: {status_message}")
 
 def create_gui():
     dpg.create_context()

--- a/app/seismic_viewer_handler.py
+++ b/app/seismic_viewer_handler.py
@@ -8,10 +8,20 @@ import numpy as np
 from obspy import read
 import os
 import threading
+import time
 
 import app_state
+from serial_handler import send_command
 
 RECORDS_FOLDER_NAME = "sismic_records"
+
+
+def _set_viewer_status(message: str) -> None:
+    """Updates the shared playback status message and marks it dirty."""
+    with app_state.data_lock:
+        app_state.viewer_playback_status = message
+        app_state.viewer_playback_status_dirty = True
+    print(f"Viewer: {message}")
 
 def get_records_folder_path():
     """Gets the absolute path to the sismic_records folder."""
@@ -21,8 +31,9 @@ def get_records_folder_path():
 def load_data_for_viewer_thread():
     """Loads all seismic data from the records folder into the viewer's state variables."""
     print("Viewer: Starting data load...")
+    _set_viewer_status("Loading seismic data...")
     folder_path = get_records_folder_path()
-    
+
     # Reset state
     app_state.viewer_seismic_files.clear()
     app_state.viewer_all_traces.clear()
@@ -32,6 +43,7 @@ def load_data_for_viewer_thread():
         files = [f for f in os.listdir(folder_path) if f.lower().endswith(('.mseed', '.msd', '.miniseed'))]
         if not files:
             print("Viewer: No seismic files found.")
+            _set_viewer_status("No seismic files found in 'sismic_records'.")
             return
 
         for file_name in files:
@@ -63,10 +75,13 @@ def load_data_for_viewer_thread():
 
     except Exception as e:
         print(f"Viewer: General error loading data: {e}")
+        _set_viewer_status(f"Error loading data: {e}")
     finally:
         # Signal the GUI thread that it needs to redraw the file list
         app_state.viewer_data_dirty.set()
         print("Viewer: Data load finished.")
+        if app_state.viewer_all_traces:
+            _set_viewer_status("Data loaded. Select a trace to play.")
 
 def process_selected_trace():
     """Processes the currently selected trace to get acceleration and displays it."""
@@ -101,3 +116,146 @@ def process_selected_trace():
                 dpg.add_line_series(times.tolist(), accel_data.tolist(), label="Acceleration")
             dpg.fit_axis_data("accel_x_axis")
             dpg.fit_axis_data("accel_y_axis")
+
+
+def _prepare_trace_for_playback(trace):
+    """Generates the displacement sequence and sampling interval for playback."""
+    working_trace = trace.copy()
+    working_trace.detrend("linear")
+    working_trace.taper(max_percentage=0.05, type="hann")
+    working_trace.integrate(method='cumtrapz')
+    working_trace.integrate(method='cumtrapz')
+
+    data = working_trace.data.astype(np.float64)
+    if data.size == 0:
+        raise ValueError("Trace contains no samples.")
+
+    max_abs = np.max(np.abs(data))
+    if not np.isfinite(max_abs) or max_abs == 0:
+        raise ValueError("Trace amplitude is zero.")
+
+    with app_state.data_lock:
+        amplitude = int(abs(app_state.viewer_playback_amplitude))
+    amplitude = max(amplitude, 1)
+
+    scaled = np.clip((data / max_abs) * amplitude, -amplitude, amplitude).astype(int)
+
+    sample_interval = getattr(working_trace.stats, "delta", None)
+    if sample_interval is None or not np.isfinite(sample_interval) or sample_interval <= 0:
+        sample_interval = 0.01
+
+    return scaled, float(sample_interval)
+
+
+def start_playback():
+    """Starts a background thread to play the selected seismic trace on the motor."""
+    if not (app_state.ser and app_state.ser.is_open):
+        _set_viewer_status("Error: Connect to the table first.")
+        return
+
+    with app_state.data_lock:
+        selected_index = app_state.viewer_selected_trace_index
+        is_running = app_state.sismo_running
+        wave_running = app_state.wave_running
+        trace_info = None
+        if (selected_index is not None and
+                0 <= selected_index < len(app_state.viewer_all_traces)):
+            trace_info = app_state.viewer_all_traces[selected_index]
+
+    if trace_info is None:
+        _set_viewer_status("Error: Select a trace before playing.")
+        return
+
+    if is_running:
+        _set_viewer_status("Playback already running.")
+        return
+
+    if wave_running:
+        _set_viewer_status("Error: Stop the sine wave generator before playback.")
+        return
+
+    with app_state.data_lock:
+        app_state.sismo_running = True
+
+    metadata = {
+        'id': trace_info['id'],
+        'file_name': trace_info['file_name'],
+        'num_samples': len(trace_info['data'])
+    }
+    trace_copy = trace_info['obspy_trace'].copy()
+
+    _set_viewer_status(f"Preparing {metadata['id']} for playback...")
+    threading.Thread(target=_playback_worker, args=(trace_copy, metadata), daemon=True).start()
+
+
+def _playback_worker(trace, metadata):
+    """Worker routine that streams the processed trace to the motor."""
+    try:
+        scaled_data, sample_interval = _prepare_trace_for_playback(trace)
+    except Exception as exc:
+        _set_viewer_status(f"Error: {exc}")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+        send_command("m0")
+        return
+
+    total_samples = len(scaled_data)
+    if total_samples == 0:
+        _set_viewer_status("Error: Trace produced no samples.")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+        send_command("m0")
+        return
+
+    sample_interval = max(sample_interval, 0.001)
+
+    with app_state.data_lock:
+        app_state.expected_wave_data.clear()
+        app_state.x_data.clear()
+        app_state.y_data.clear()
+        app_state.plot_start_time = time.time()
+
+    if dpg.does_item_exist("speed_input"):
+        send_command(f"s{dpg.get_value('speed_input')}")
+    if dpg.does_item_exist("accel_input"):
+        send_command(f"a{dpg.get_value('accel_input')}")
+
+    _set_viewer_status(f"Playing {total_samples} samples from {metadata.get('file_name', 'trace')}...")
+
+    playback_start = time.time()
+    try:
+        for raw_position in scaled_data:
+            if not app_state.sismo_running:
+                _set_viewer_status("Playback stopped by user.")
+                send_command("m0")
+                return
+
+            position = int(raw_position)
+            send_command(f"m{position}")
+
+            current_time = time.time() - playback_start
+            with app_state.data_lock:
+                app_state.expected_wave_data.append((current_time, position))
+                if len(app_state.expected_wave_data) > app_state.max_points:
+                    app_state.expected_wave_data.popleft()
+
+            time.sleep(sample_interval)
+
+    except Exception as exc:
+        _set_viewer_status(f"Error during playback: {exc}")
+    else:
+        _set_viewer_status("Playback finished.")
+    finally:
+        send_command("m0")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+
+
+def stop_playback():
+    """Signals the playback thread to stop streaming commands."""
+    with app_state.data_lock:
+        was_running = app_state.sismo_running
+        app_state.sismo_running = False
+
+    if was_running:
+        _set_viewer_status("Stopping playback...")


### PR DESCRIPTION
## Summary
- add playback state tracking to the shared app state and expose amplitude control in the viewer tab
- implement a seismic viewer playback worker that scales the selected trace and streams motor commands over serial
- update the GUI to show playback status and provide play/stop controls tied to the new worker

## Testing
- python -m compileall sistema-mesa-sismica/app

------
https://chatgpt.com/codex/tasks/task_e_68d221ebe0508330be476265344612ad