### PR TITLE
Fix viewer playback marker parent and bounds

### DIFF
--- a/app/app_state.py
+++ b/app/app_state.py
@@ -19,3 +19,10 @@ viewer_seismic_files = {}           # Files and their traces for the viewer
 viewer_all_traces = []              # Flat list of all traces
 viewer_selected_trace_index = None  # Index of the selected trace
 viewer_data_dirty = threading.Event() # Event to notify GUI to update viewer
+
+viewer_playback_status = "Idle"
+viewer_playback_status_dirty = False
+viewer_playback_amplitude = 1600
+viewer_playback_start_time = 0.0
+viewer_playback_paused = False
+viewer_playback_time_bounds = (0.0, 0.0)

--- a/app/gui.py
+++ b/app/gui.py
@@ -3,7 +3,6 @@
 import dearpygui.dearpygui as dpg
 import threading
 import time
-import numpy as np
 
 import app_state
 from serial_handler import (find_serial_ports, connect_serial, disconnect_serial, send_command, wave_generator_thread)
@@ -101,9 +100,41 @@ def stop_wave_callback():
 
 def _viewer_on_trace_select(sender, app_data, user_data):
     """Callback triggered when a trace in the viewer is clicked."""
-    app_state.viewer_selected_trace_index = user_data
+    with app_state.data_lock:
+        app_state.viewer_selected_trace_index = user_data
+        app_state.viewer_playback_start_time = 0.0
     _update_viewer_file_tree()
     _update_viewer_detailed_plot()
+
+
+def _viewer_update_start_time_label(value: float) -> None:
+    """Updates the start time label below the detailed plot."""
+    if dpg.does_item_exist("viewer_playback_marker_label"):
+        dpg.set_value("viewer_playback_marker_label", f"Selected start time: {value:.2f} s")
+
+
+def _viewer_start_marker_changed(sender, app_data):
+    """Stores the start time selected with the draggable marker."""
+    try:
+        raw_value = float(app_data)
+    except (TypeError, ValueError):
+        return
+
+    with app_state.data_lock:
+        min_time, max_time = app_state.viewer_playback_time_bounds
+
+    if min_time > max_time:
+        min_time, max_time = max_time, min_time
+
+    new_value = min(max(raw_value, min_time), max_time)
+
+    with app_state.data_lock:
+        app_state.viewer_playback_start_time = new_value
+
+    if dpg.does_item_exist("viewer_playback_marker") and abs(new_value - raw_value) > 1e-9:
+        dpg.set_value("viewer_playback_marker", new_value)
+
+    _viewer_update_start_time_label(new_value)
 
 def _update_viewer_file_tree():
     """Redraws the file list and traces in the left panel of the viewer."""
@@ -142,14 +173,66 @@ def _update_viewer_detailed_plot():
             f"Max Amplitude: {trace_data['max_amp']:.3e}")
     dpg.add_text(info, parent=parent_container)
     dpg.add_separator(parent=parent_container)
-    with dpg.plot(label="Detailed View", height=-50, width=-1, parent=parent_container):
+    times = trace_data['times'].tolist()
+    samples = trace_data['data'].tolist()
+    min_time = float(times[0]) if times else 0.0
+    max_time = float(times[-1]) if times else 0.0
+
+    with app_state.data_lock:
+        start_time = float(app_state.viewer_playback_start_time)
+        app_state.viewer_playback_time_bounds = (min_time, max_time)
+
+    if max_time < min_time:
+        max_time = min_time
+
+    start_time = min(max(start_time, min_time), max_time)
+
+    with app_state.data_lock:
+        app_state.viewer_playback_start_time = start_time
+
+    with dpg.plot(label="Detailed View", height=-50, width=-1, parent=parent_container) as plot_id:
         x_axis = dpg.add_plot_axis(dpg.mvXAxis, label="Time (s)")
         with dpg.plot_axis(dpg.mvYAxis, label="Amplitude") as y_axis:
-            dpg.add_line_series(trace_data['times'].tolist(), trace_data['data'].tolist(), label=trace_data['id'])
+            dpg.add_line_series(times, samples, label=trace_data['id'])
+        if times:
+            dpg.add_drag_line(tag="viewer_playback_marker",
+                              default_value=start_time,
+                              vertical=True,
+                              color=(255, 0, 0, 180),
+                              thickness=2,
+                              callback=_viewer_start_marker_changed,
+                              parent=plot_id)
         dpg.fit_axis_data(x_axis)
         dpg.fit_axis_data(y_axis)
+
     with dpg.group(horizontal=True, parent=parent_container):
-        dpg.add_button(label="Process for Shaking Table", callback=svh.process_selected_trace, width=-1, height=30)
+        dpg.add_button(label="Process", callback=svh.process_selected_trace, width=180, height=30)
+        dpg.add_button(label="Play on Table", tag="viewer_play_button", callback=svh.start_playback, width=160, height=30)
+        dpg.add_button(label="Pause", tag="viewer_pause_button", callback=svh.toggle_pause_playback, width=120, height=30)
+        dpg.add_button(label="Stop", tag="viewer_stop_button", callback=svh.stop_playback, width=120, height=30)
+    dpg.add_text("Selected start time: 0.00 s", tag="viewer_playback_marker_label", parent=parent_container)
+    _viewer_update_start_time_label(start_time)
+    dpg.add_slider_int(label="Playback Amplitude (steps)",
+                       tag="viewer_playback_amplitude_slider",
+                       default_value=app_state.viewer_playback_amplitude,
+                       min_value=100,
+                       max_value=10000,
+                       callback=_viewer_amplitude_changed,
+                       parent=parent_container)
+    dpg.add_text(f"Status: {app_state.viewer_playback_status}",
+                 tag="viewer_playback_status_label",
+                 parent=parent_container)
+    dpg.add_separator(parent=parent_container)
+    dpg.add_text("Commands sent to motor", parent=parent_container)
+    with dpg.child_window(tag="viewer_command_log_container", parent=parent_container, height=140, border=True):
+        dpg.add_input_text(tag="viewer_command_log_output", multiline=True, readonly=True, width=-1, height=-1)
+
+
+def _viewer_amplitude_changed(sender, app_data):
+    """Stores the latest amplitude selected by the user for playback."""
+    with app_state.data_lock:
+        app_state.viewer_playback_amplitude = int(app_data)
+
 
 # <<< END: VIEWER FUNCTIONS >>>
 
@@ -161,7 +244,7 @@ def update_gui_callbacks():
         _update_viewer_file_tree()
         _update_viewer_detailed_plot()
         app_state.viewer_data_dirty.clear()
-    
+
     # <<< REMOVED LOGIC RELATED TO THE DELETED SISMOS LOCALES TAB >>>
     # if app_state.sismo_list_dirty:
     #     update_sismo_visual_list()
@@ -170,6 +253,9 @@ def update_gui_callbacks():
     # if dpg.does_item_exist("sismo_status"): dpg.set_value("sismo_status", app_state.sismo_status_message)
     # if dpg.does_item_exist("sismo_playback_status"): dpg.set_value("sismo_playback_status", app_state.sismo_playback_status_message)
     
+    status_dirty = False
+    status_message = ""
+    is_playing = False
     with app_state.data_lock:
         if app_state.x_data and app_state.y_data and dpg.does_item_exist("series_real_comp"):
             dpg.set_value("series_real_comp", [list(app_state.x_data), list(app_state.y_data)])
@@ -187,7 +273,45 @@ def update_gui_callbacks():
             if dpg.does_item_exist("console_send_output"): dpg.set_value("console_send_output", "\n".join(app_state.log_sent))
             if dpg.does_item_exist("console_recv_container"): dpg.set_y_scroll("console_recv_container", -1.0)
             if dpg.does_item_exist("console_send_container"): dpg.set_y_scroll("console_send_container", -1.0)
+            if dpg.does_item_exist("viewer_command_log_output"): dpg.set_value("viewer_command_log_output", "\n".join(app_state.log_sent))
+            if dpg.does_item_exist("viewer_command_log_container"): dpg.set_y_scroll("viewer_command_log_container", -1.0)
             app_state.log_dirty = False
+
+        if app_state.viewer_playback_status_dirty:
+            status_dirty = True
+            status_message = app_state.viewer_playback_status
+            app_state.viewer_playback_status_dirty = False
+
+        is_playing = app_state.sismo_running
+        is_paused = app_state.viewer_playback_paused
+        start_time = app_state.viewer_playback_start_time
+
+    _viewer_update_start_time_label(start_time)
+
+    is_connected = bool(app_state.ser and app_state.ser.is_open)
+
+    if dpg.does_item_exist("viewer_play_button"):
+        if is_playing or not is_connected:
+            dpg.disable_item("viewer_play_button")
+        else:
+            dpg.enable_item("viewer_play_button")
+
+    if dpg.does_item_exist("viewer_pause_button"):
+        if is_playing:
+            dpg.enable_item("viewer_pause_button")
+            dpg.set_item_label("viewer_pause_button", "Resume" if is_paused else "Pause")
+        else:
+            dpg.disable_item("viewer_pause_button")
+            dpg.set_item_label("viewer_pause_button", "Pause")
+
+    if dpg.does_item_exist("viewer_stop_button"):
+        if is_playing:
+            dpg.enable_item("viewer_stop_button")
+        else:
+            dpg.disable_item("viewer_stop_button")
+
+    if status_dirty and dpg.does_item_exist("viewer_playback_status_label"):
+        dpg.set_value("viewer_playback_status_label", f"Status: {status_message}")
 
 def create_gui():
     dpg.create_context()

--- a/app/seismic_viewer_handler.py
+++ b/app/seismic_viewer_handler.py
@@ -8,10 +8,20 @@ import numpy as np
 from obspy import read
 import os
 import threading
+import time
 
 import app_state
+from serial_handler import send_command
 
 RECORDS_FOLDER_NAME = "sismic_records"
+
+
+def _set_viewer_status(message: str) -> None:
+    """Updates the shared playback status message and marks it dirty."""
+    with app_state.data_lock:
+        app_state.viewer_playback_status = message
+        app_state.viewer_playback_status_dirty = True
+    print(f"Viewer: {message}")
 
 def get_records_folder_path():
     """Gets the absolute path to the sismic_records folder."""
@@ -21,17 +31,22 @@ def get_records_folder_path():
 def load_data_for_viewer_thread():
     """Loads all seismic data from the records folder into the viewer's state variables."""
     print("Viewer: Starting data load...")
+    _set_viewer_status("Loading seismic data...")
     folder_path = get_records_folder_path()
-    
+
     # Reset state
     app_state.viewer_seismic_files.clear()
     app_state.viewer_all_traces.clear()
-    app_state.viewer_selected_trace_index = None
+    with app_state.data_lock:
+        app_state.viewer_selected_trace_index = None
+        app_state.viewer_playback_start_time = 0.0
+        app_state.viewer_playback_paused = False
 
     try:
         files = [f for f in os.listdir(folder_path) if f.lower().endswith(('.mseed', '.msd', '.miniseed'))]
         if not files:
             print("Viewer: No seismic files found.")
+            _set_viewer_status("No seismic files found in 'sismic_records'.")
             return
 
         for file_name in files:
@@ -63,10 +78,13 @@ def load_data_for_viewer_thread():
 
     except Exception as e:
         print(f"Viewer: General error loading data: {e}")
+        _set_viewer_status(f"Error loading data: {e}")
     finally:
         # Signal the GUI thread that it needs to redraw the file list
         app_state.viewer_data_dirty.set()
         print("Viewer: Data load finished.")
+        if app_state.viewer_all_traces:
+            _set_viewer_status("Data loaded. Select a trace to play.")
 
 def process_selected_trace():
     """Processes the currently selected trace to get acceleration and displays it."""
@@ -101,3 +119,217 @@ def process_selected_trace():
                 dpg.add_line_series(times.tolist(), accel_data.tolist(), label="Acceleration")
             dpg.fit_axis_data("accel_x_axis")
             dpg.fit_axis_data("accel_y_axis")
+
+
+def _prepare_trace_for_playback(trace):
+    """Generates the displacement sequence and sampling interval for playback."""
+    working_trace = trace.copy()
+    working_trace.detrend("linear")
+    working_trace.taper(max_percentage=0.05, type="hann")
+    working_trace.integrate(method='cumtrapz')
+    working_trace.integrate(method='cumtrapz')
+
+    data = working_trace.data.astype(np.float64)
+    if data.size == 0:
+        raise ValueError("Trace contains no samples.")
+
+    max_abs = np.max(np.abs(data))
+    if not np.isfinite(max_abs) or max_abs == 0:
+        raise ValueError("Trace amplitude is zero.")
+
+    with app_state.data_lock:
+        amplitude = int(abs(app_state.viewer_playback_amplitude))
+    amplitude = max(amplitude, 1)
+
+    scaled = np.clip((data / max_abs) * amplitude, -amplitude, amplitude).astype(int)
+
+    sample_interval = getattr(working_trace.stats, "delta", None)
+    if sample_interval is None or not np.isfinite(sample_interval) or sample_interval <= 0:
+        sample_interval = 0.01
+
+    return scaled, float(sample_interval)
+
+
+def start_playback():
+    """Starts a background thread to play the selected seismic trace on the motor."""
+    if not (app_state.ser and app_state.ser.is_open):
+        _set_viewer_status("Error: Connect to the table first.")
+        return
+
+    with app_state.data_lock:
+        selected_index = app_state.viewer_selected_trace_index
+        is_running = app_state.sismo_running
+        wave_running = app_state.wave_running
+        trace_info = None
+        if (selected_index is not None and
+                0 <= selected_index < len(app_state.viewer_all_traces)):
+            trace_info = app_state.viewer_all_traces[selected_index]
+
+    if trace_info is None:
+        _set_viewer_status("Error: Select a trace before playing.")
+        return
+
+    if is_running:
+        _set_viewer_status("Playback already running.")
+        return
+
+    if wave_running:
+        _set_viewer_status("Error: Stop the sine wave generator before playback.")
+        return
+
+    with app_state.data_lock:
+        app_state.sismo_running = True
+        app_state.viewer_playback_paused = False
+
+    metadata = {
+        'id': trace_info['id'],
+        'file_name': trace_info['file_name'],
+        'num_samples': len(trace_info['data'])
+    }
+    trace_copy = trace_info['obspy_trace'].copy()
+
+    _set_viewer_status(f"Preparing {metadata['id']} for playback...")
+    threading.Thread(target=_playback_worker, args=(trace_copy, metadata), daemon=True).start()
+
+
+def _playback_worker(trace, metadata):
+    """Worker routine that streams the processed trace to the motor."""
+    try:
+        scaled_data, sample_interval = _prepare_trace_for_playback(trace)
+    except Exception as exc:
+        _set_viewer_status(f"Error: {exc}")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+            app_state.viewer_playback_paused = False
+        send_command("m0")
+        return
+
+    total_samples = len(scaled_data)
+    if total_samples == 0:
+        _set_viewer_status("Error: Trace produced no samples.")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+            app_state.viewer_playback_paused = False
+        send_command("m0")
+        return
+
+    sample_interval = max(sample_interval, 0.001)
+
+    with app_state.data_lock:
+        start_time = max(0.0, float(app_state.viewer_playback_start_time))
+
+    start_index = int(start_time / sample_interval) if sample_interval > 0 else 0
+    if start_index >= total_samples:
+        start_index = max(total_samples - 1, 0)
+
+    if start_index > 0:
+        scaled_data = scaled_data[start_index:]
+        total_samples = len(scaled_data)
+
+    with app_state.data_lock:
+        app_state.viewer_playback_paused = False
+
+    with app_state.data_lock:
+        app_state.expected_wave_data.clear()
+        app_state.x_data.clear()
+        app_state.y_data.clear()
+        app_state.plot_start_time = time.time()
+
+    if dpg.does_item_exist("speed_input"):
+        send_command(f"s{dpg.get_value('speed_input')}")
+    if dpg.does_item_exist("accel_input"):
+        send_command(f"a{dpg.get_value('accel_input')}")
+
+    if start_index > 0:
+        _set_viewer_status(
+            f"Playing {total_samples} samples from {metadata.get('file_name', 'trace')} (starting at {start_time:.2f}s)...")
+    else:
+        _set_viewer_status(f"Playing {total_samples} samples from {metadata.get('file_name', 'trace')}...")
+
+    playback_offset = start_index * sample_interval
+    playback_start = time.time() - playback_offset
+    previous_position = 0
+    last_sample_time = 0.0
+    stopped_by_user = False
+    try:
+        for raw_position in scaled_data:
+            while True:
+                with app_state.data_lock:
+                    running = app_state.sismo_running
+                    paused = app_state.viewer_playback_paused
+                if not running:
+                    stopped_by_user = True
+                    break
+                if not paused:
+                    break
+                time.sleep(0.05)
+
+            if stopped_by_user:
+                break
+
+            target_position = int(raw_position)
+            delta_steps = target_position - previous_position
+            if delta_steps != 0:
+                send_command(f"m{delta_steps}")
+            previous_position = target_position
+
+            current_time = time.time() - playback_start
+            last_sample_time = current_time
+            with app_state.data_lock:
+                app_state.expected_wave_data.append((current_time, target_position))
+                if len(app_state.expected_wave_data) > app_state.max_points:
+                    app_state.expected_wave_data.popleft()
+
+            time.sleep(sample_interval)
+
+    except Exception as exc:
+        _set_viewer_status(f"Error during playback: {exc}")
+    else:
+        if not stopped_by_user:
+            _set_viewer_status("Playback finished.")
+    finally:
+        if previous_position != 0:
+            send_command(f"m{-previous_position}")
+            final_time = last_sample_time + sample_interval
+            with app_state.data_lock:
+                app_state.expected_wave_data.append((final_time, 0))
+                if len(app_state.expected_wave_data) > app_state.max_points:
+                    app_state.expected_wave_data.popleft()
+        send_command("m0")
+        with app_state.data_lock:
+            app_state.sismo_running = False
+            app_state.viewer_playback_paused = False
+
+    if stopped_by_user:
+        _set_viewer_status("Playback stopped by user.")
+
+
+def stop_playback():
+    """Signals the playback thread to stop streaming commands."""
+    with app_state.data_lock:
+        was_running = app_state.sismo_running
+        app_state.sismo_running = False
+        app_state.viewer_playback_paused = False
+
+    if was_running:
+        _set_viewer_status("Stopping playback...")
+
+
+def toggle_pause_playback():
+    """Toggles between paused and resumed playback states."""
+    with app_state.data_lock:
+        is_running = app_state.sismo_running
+        is_paused = app_state.viewer_playback_paused
+
+    if not is_running:
+        _set_viewer_status("Playback is not running.")
+        return
+
+    with app_state.data_lock:
+        app_state.viewer_playback_paused = not is_paused
+        now_paused = app_state.viewer_playback_paused
+
+    if now_paused:
+        _set_viewer_status("Playback paused.")
+    else:
+        _set_viewer_status("Resuming playback...")

--- a/app/serial_handler.py
+++ b/app/serial_handler.py
@@ -98,10 +98,17 @@ def wave_generator_thread():
     frequency = dpg.get_value("frequency_slider")
     start_time = time.time()
     
+    previous_position = 0
     while app_state.wave_running:
         elapsed_time = time.time() - start_time
         target_pos = amplitude * math.sin(2 * math.pi * frequency * elapsed_time)
-        send_command(f"m{int(target_pos)}")
+        target_steps = int(target_pos)
+        delta_steps = target_steps - previous_position
+        if delta_steps != 0:
+            send_command(f"m{delta_steps}")
+        previous_position = target_steps
         time.sleep(0.02)
-    
+
+    if previous_position != 0:
+        send_command(f"m{-previous_position}")
     send_command("m0")


### PR DESCRIPTION
## Summary
- store the viewer playback time bounds in shared state and clamp the draggable marker to the loaded trace range
- attach the drag line to the detailed plot itself so Dear PyGui accepts the widget and keep the UI marker in sync with the stored start time

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d221ebe0508330be476265344612ad